### PR TITLE
Allow plugins to change the redirection URL after wpcs auto login

### DIFF
--- a/packages/waas-client/src/Api/SingleSignOnController.php
+++ b/packages/waas-client/src/Api/SingleSignOnController.php
@@ -74,7 +74,8 @@ class SingleSignOnController
         wp_set_current_user($user->ID);
         wp_set_auth_cookie($user->ID);
         do_action('wp_login', $user->user_login, $user);
-        wp_redirect(admin_url());
+        $redirect_to = apply_filters('wildcloud/sso/admin_url', admin_url(), $user, $data);
+        wp_redirect($redirect_to);
         exit();
     }
 }

--- a/packages/waas-client/src/Api/SingleSignOnController.php
+++ b/packages/waas-client/src/Api/SingleSignOnController.php
@@ -74,7 +74,7 @@ class SingleSignOnController
         wp_set_current_user($user->ID);
         wp_set_auth_cookie($user->ID);
         do_action('wp_login', $user->user_login, $user);
-        $redirect_to = apply_filters('wildcloud/sso/admin_url', admin_url(), $user, $data);
+        $redirect_to = apply_filters('wildcloud_sso_admin_url', admin_url(), $user, $data);
         wp_redirect($redirect_to);
         exit();
     }


### PR DESCRIPTION
Hook used by WP Frontend Admin to redirect users to the front end dashboard site instead of the wp-admin dashboard.